### PR TITLE
Use std::cmp::reverse for sorting output

### DIFF
--- a/src/fmt_mount.rs
+++ b/src/fmt_mount.rs
@@ -3,13 +3,7 @@ use {
     file_size,
     lfs_core::*,
     minimad::{OwningTemplateExpander, TextTemplate},
-    termimad::{
-        terminal_size,
-        CompoundStyle,
-        FmtText,
-        MadSkin,
-        ProgressBar,
-    },
+    termimad::{terminal_size, CompoundStyle, FmtText, MadSkin, ProgressBar},
 };
 
 // those colors are chosen to be "redish" for used, "greenish" for available
@@ -47,8 +41,7 @@ pub fn print(mounts: &[Mount]) -> Result<()> {
         if let Some(stats) = mount.stats.as_ref().filter(|s| s.size() > 0) {
             let use_share = stats.use_share();
             let pb = ProgressBar::new(use_share as f32, BAR_WIDTH);
-            sub
-                .set("size", file_size::fit_4(stats.size()))
+            sub.set("size", file_size::fit_4(stats.size()))
                 .set("used", file_size::fit_4(stats.used()))
                 .set("use-percents", format!("{:.0}%", 100.0 * use_share))
                 .set("bar", format!("{:<width$}", pb, width = BAR_WIDTH))

--- a/src/json.rs
+++ b/src/json.rs
@@ -42,6 +42,6 @@ pub fn output_value(mounts: &[Mount]) -> Value {
                     "stats": stats,
                 })
             })
-            .collect()
+            .collect(),
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,7 @@ mod json;
 
 use {
     argh::FromArgs,
-    std::{
-        fs,
-        os::unix::fs::MetadataExt,
-        path::PathBuf,
-    },
+    std::{fs, os::unix::fs::MetadataExt, path::PathBuf},
 };
 
 #[derive(FromArgs)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod json;
 
 use {
     argh::FromArgs,
-    std::{fs, os::unix::fs::MetadataExt, path::PathBuf},
+    std::{cmp::Reverse, fs, os::unix::fs::MetadataExt, path::PathBuf},
 };
 
 #[derive(FromArgs)]
@@ -58,7 +58,7 @@ fn main() -> lfs_core::Result<()> {
         println!("no disk was found - try\n    lfs -a");
         Ok(())
     } else {
-        mounts.sort_by_key(|m| u64::MAX - m.size());
+        mounts.sort_by_key(|m| Reverse(m.size()));
         fmt_mount::print(&mounts)
     }
 }


### PR DESCRIPTION
It's way more obvious to say `Reverse(m.size())` instead of `u64::MAX - m.size` to tell the intention.